### PR TITLE
fix(products): preserve existing price conditions in product filtering

### DIFF
--- a/src/modules/products/server/procedures.ts
+++ b/src/modules/products/server/procedures.ts
@@ -19,12 +19,14 @@ export const productsRouter = createTRPCRouter({
 
 			if (input.minPrice) {
 				where.price = {
+					...where.price,
 					greater_than_equal: input.minPrice,
 				};
 			}
 
 			if (input.maxPrice) {
 				where.price = {
+					...where.price,
 					less_than_equal: input.maxPrice,
 				};
 			}


### PR DESCRIPTION
The existing price conditions were being overwritten when applying minPrice and maxPrice filters. This commit ensures that any existing price conditions are preserved by using the spread operator to merge the new conditions with the existing ones.